### PR TITLE
[tests] remove deprecated ``html5lib``

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ dynamic = ["version"]
 [project.optional-dependencies]
 test = [
     "pytest",
-    "html5lib",
 ]
 lint = [
     "flake8",

--- a/tests/test_htmlhelp.py
+++ b/tests/test_htmlhelp.py
@@ -4,7 +4,7 @@ import re
 from pathlib import Path
 
 import pytest
-from html5lib import HTMLParser
+from xml.etree.ElementTree import parse as xml_parse
 
 from sphinxcontrib.htmlhelp import chm_htmlescape, default_htmlhelp_basename
 from sphinx.config import Config
@@ -76,8 +76,8 @@ def test_htmlhelp_hhc(app):
 
     # .hhc file
     hhc = (app.outdir / 'pythondoc.hhc').read_text()
-    tree = HTMLParser(namespaceHTMLElements=False).parse(hhc)
-    items = tree.find('.//body/ul')
+    etree = xml_parse(app.outdir / 'pythondoc.hhc')
+    items = etree.find('.//body/ul')
     assert len(items) == 4
 
     # index


### PR DESCRIPTION
See: https://github.com/sphinx-doc/sphinx/pull/12173

@AA-Turner I don't know how to make a release (and I'm not sure I have the credentials for that). In addition, I see that HEAD contains a 2.0.4 version but pypi contains a 2.0.5 version... which one is the correct one..?