### PR TITLE
Type and version fixes to make linter run again

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v5
         with:
-          python-version: "3"
+          python-version: "3.14"
 
       - name: Install dependencies
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ include = [
 ]
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 packages = [
     "sphinxcontrib",
     "tests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ urls.Download = "https://pypi.org/project/sphinxcontrib-htmlhelp/"
 urls.Homepage = "https://www.sphinx-doc.org/"
 urls."Issue tracker" = "https://github.com/sphinx-doc/sphinx/issues/"
 license.text = "BSD-2-Clause"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 # Classifiers list: https://pypi.org/classifiers/
 classifiers = [
@@ -27,11 +27,12 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Framework :: Sphinx",
     "Framework :: Sphinx :: Extension",
     "Topic :: Documentation",
@@ -73,7 +74,7 @@ include = [
 ]
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 packages = [
     "sphinxcontrib",
     "tests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ urls.Download = "https://pypi.org/project/sphinxcontrib-htmlhelp/"
 urls.Homepage = "https://www.sphinx-doc.org/"
 urls."Issue tracker" = "https://github.com/sphinx-doc/sphinx/issues/"
 license.text = "BSD-2-Clause"
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 
 # Classifiers list: https://pypi.org/classifiers/
 classifiers = [
@@ -27,12 +27,11 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "Programming Language :: Python :: 3.14",
-    "Programming Language :: Python :: 3.15",
     "Framework :: Sphinx",
     "Framework :: Sphinx :: Extension",
     "Topic :: Documentation",
@@ -74,7 +73,7 @@ include = [
 ]
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.9"
 packages = [
     "sphinxcontrib",
     "tests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ lint = [
     "ruff==0.5.5",
     "mypy",
     "types-docutils",
+    "types-html5lib",
 ]
 standalone = [
     "Sphinx>=5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ include = [
 ]
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.12"
 packages = [
     "sphinxcontrib",
     "tests",

--- a/sphinxcontrib/htmlhelp/__init__.py
+++ b/sphinxcontrib/htmlhelp/__init__.py
@@ -8,7 +8,7 @@ import re
 from html.entities import codepoint2name
 from os import path
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, AbstractSet
 
 import sphinx
 from docutils import nodes
@@ -170,7 +170,7 @@ class HTMLHelpBuilder(StandaloneHTMLBuilder):
         if locale is not None:
             self.lcid, self.encoding = locale
 
-    def prepare_writing(self, docnames: set[str]) -> None:
+    def prepare_writing(self, docnames: AbstractSet[str]) -> None:
         super().prepare_writing(docnames)
         self.globalcontext['html5_doctype'] = False
 

--- a/sphinxcontrib/htmlhelp/__init__.py
+++ b/sphinxcontrib/htmlhelp/__init__.py
@@ -8,7 +8,7 @@ import re
 from html.entities import codepoint2name
 from os import path
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, Optional, Union
 
 import sphinx
 from docutils import nodes
@@ -285,7 +285,7 @@ class HTMLHelpBuilder(StandaloneHTMLBuilder):
         with open(filename, 'w', encoding=self.encoding, errors='xmlcharrefreplace') as f:
             f.write('<UL>\n')
 
-            IndexEntryTargets = list[tuple[str | None, str | Literal[False]]]
+            IndexEntryTargets = list[tuple[Optional[str], Union[str, Literal[False]]]]
 
             def write_index(
                 title: str,

--- a/sphinxcontrib/htmlhelp/__init__.py
+++ b/sphinxcontrib/htmlhelp/__init__.py
@@ -8,7 +8,7 @@ import re
 from html.entities import codepoint2name
 from os import path
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, AbstractSet
+from typing import TYPE_CHECKING, Any
 
 import sphinx
 from docutils import nodes
@@ -23,6 +23,8 @@ from sphinx.util.osutil import make_filename_from_project, relpath
 from sphinx.util.template import SphinxRenderer
 
 if TYPE_CHECKING:
+    from collections.abc import Set
+
     from docutils.nodes import Element, Node
     from sphinx.application import Sphinx
     from sphinx.config import Config
@@ -170,7 +172,7 @@ class HTMLHelpBuilder(StandaloneHTMLBuilder):
         if locale is not None:
             self.lcid, self.encoding = locale
 
-    def prepare_writing(self, docnames: AbstractSet[str]) -> None:
+    def prepare_writing(self, docnames: Set[str]) -> None:
         super().prepare_writing(docnames)
         self.globalcontext['html5_doctype'] = False
 

--- a/sphinxcontrib/htmlhelp/__init__.py
+++ b/sphinxcontrib/htmlhelp/__init__.py
@@ -8,7 +8,7 @@ import re
 from html.entities import codepoint2name
 from os import path
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 import sphinx
 from docutils import nodes
@@ -285,10 +285,12 @@ class HTMLHelpBuilder(StandaloneHTMLBuilder):
         with open(filename, 'w', encoding=self.encoding, errors='xmlcharrefreplace') as f:
             f.write('<UL>\n')
 
+            IndexEntryTargets = list[tuple[str | None, str | Literal[False]]]
+
             def write_index(
                 title: str,
-                refs: list[tuple[str, str]],
-                subitems: list[tuple[str, list[tuple[str, str]]]],
+                refs: IndexEntryTargets,
+                subitems: list[tuple[str, IndexEntryTargets]],
             ) -> None:
                 def write_param(name: str, value: str) -> None:
                     item = f'    <param name="{name}" value="{value}">\n'
@@ -299,12 +301,16 @@ class HTMLHelpBuilder(StandaloneHTMLBuilder):
                 if len(refs) == 0:
                     write_param('See Also', title)
                 elif len(refs) == 1:
-                    write_param('Local', refs[0][1])
+                    target = refs[0][1]
+                    if target is not False:
+                        write_param('Local', target)
                 else:
                     for i, ref in enumerate(refs):
                         # XXX: better title?
-                        write_param('Name', '[%d] %s' % (i, ref[1]))
-                        write_param('Local', ref[1])
+                        target = ref[1]
+                        if target is not False:
+                            write_param('Name', '[%d] %s' % (i, target))
+                            write_param('Local', target)
                 f.write('</OBJECT>\n')
                 if subitems:
                     f.write('<UL> ')

--- a/tests/roots/test-chm/index.rst
+++ b/tests/roots/test-chm/index.rst
@@ -6,7 +6,7 @@ Index markup
    pair: entry; pair
    double: entry; double
    triple: index; entry; triple
-   keyword: with
+   pair: keyword; with
    see: from; to
    seealso: fromalso; toalso
 


### PR DESCRIPTION
Discovered in another PR that the CI is failing for a few unrelated reasons.

The mypy-lint-tests don't run anymore on `python 3.9` -> require `3.12`.

Fixes also problems that were (I think) mismatches with the newer sphinx version.

With newer python versions I got this failure (also fixed):
```
FAILED tests/test_htmlhelp.py::test_chm - ValueError: 'keyword' is no longer supported for index entries (from entry 'keyword: with'). Use 'pair: keyword; with' instead
```